### PR TITLE
fix(normalize): Correct uTorrent tuple mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ console.log(res);
 
 ### See Also
 
-- shared types - [@ctrl/shared-torrent](https://github.com/scttcper/shared-torrent)  
-- deluge - [@ctrl/deluge](https://github.com/scttcper/deluge)  
-- transmission - [@ctrl/transmission](https://github.com/scttcper/transmission)  
-- qbittorrent - [@ctrl/qbittorrent](https://github.com/scttcper/qbittorrent)  
+- shared types - [@ctrl/shared-torrent](https://github.com/scttcper/shared-torrent)
+- deluge - [@ctrl/deluge](https://github.com/scttcper/deluge)
+- transmission - [@ctrl/transmission](https://github.com/scttcper/transmission)
+- qbittorrent - [@ctrl/qbittorrent](https://github.com/scttcper/qbittorrent)
 - rtorrent - [@ctrl/rtorrent](https://github.com/scttcper/rtorrent)
 
 ### Start a test docker container

--- a/src/normalizeTorrentData.ts
+++ b/src/normalizeTorrentData.ts
@@ -14,6 +14,7 @@ export function normalizeTorrentData(torrent: TorrentData): NormalizedTorrent {
   const progress: number = torrent[4] / 10;
   const done = progress >= 100;
   const isCompleted = progress >= 100;
+  const dateCompleted = torrent[24] ? new Date(torrent[24] * 1000).toISOString() : undefined;
 
   // TODO: Convert from bitwise
 
@@ -58,7 +59,7 @@ export function normalizeTorrentData(torrent: TorrentData): NormalizedTorrent {
     progress,
     ratio: torrent[7] / 1000,
     dateAdded: new Date(torrent[23] * 1000).toISOString(),
-    dateCompleted: new Date(torrent[24] * 1000).toISOString(),
+    dateCompleted,
     label: torrent[11],
     savePath: torrent[26],
     uploadSpeed: torrent[8],
@@ -69,7 +70,7 @@ export function normalizeTorrentData(torrent: TorrentData): NormalizedTorrent {
     connectedSeeds: torrent[14],
     totalPeers: torrent[13],
     totalSeeds: torrent[15],
-    totalSelected: torrent[18],
+    totalSelected: torrent[3],
     totalSize: torrent[3],
     totalUploaded: torrent[6],
     totalDownloaded: torrent[5],

--- a/src/normalizeTorrentData.ts
+++ b/src/normalizeTorrentData.ts
@@ -11,7 +11,7 @@ const STATE_QUEUED = 64;
 
 export function normalizeTorrentData(torrent: TorrentData): NormalizedTorrent {
   const torrentState: number = torrent[1];
-  const progress: number = torrent[4] / 100;
+  const progress: number = torrent[4] / 10;
   const done = progress >= 100;
   const isCompleted = progress >= 100;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,15 @@ export interface TorrentListResponse extends BaseResponse {
  * SEEDS IN SWARM (integer)
  * AVAILABILITY (integer in 1/65536ths)
  * TORRENT QUEUE ORDER (integer)
- * REMAINING (integer in bytes)
+ * REMAINING (integer in bytes left to download)
+ * DOWNLOAD URL (string)
+ * RSS FEED URL (string)
+ * STATUS MESSAGE (string)
+ * STREAM ID (string)
+ * DATE ADDED (Unix timestamp in seconds)
+ * DATE COMPLETED (Unix timestamp in seconds, 0 when incomplete)
+ * APP UPDATE URL (string)
+ * SAVE PATH (string)
  */
 export type TorrentData = [
   HASH: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export interface TorrentListResponse extends BaseResponse {
  * STATUS* (integer)
  * NAME (string)
  * SIZE (integer in bytes)
- * PERCENT PROGRESS (integer in per mils)
+ * PERCENT PROGRESS (integer in tenths of a percent, 1000 = 100%)
  * DOWNLOADED (integer in bytes)
  * UPLOADED (integer in bytes)
  * RATIO (integer in per mils)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -97,9 +97,11 @@ it('should return normalized torrent data', async () => {
   // expect(torrent.savePath).toBe('/utorrent/data/incomplete');
   // expect(torrent.state).toBe(TorrentState.queued);
   expect(torrent.stateMessage).toBe('');
+  expect(torrent.dateCompleted).toBeUndefined();
   expect(torrent.totalDownloaded).toBe(0);
   expect(torrent.totalPeers).toBe(0);
   expect(torrent.totalSeeds).toBe(0);
+  expect(torrent.totalSelected).toBe(torrent.totalSize);
   // expect(torrent.totalSelected).toBe(1953349632);
   // expect(torrent.totalSize).toBe(1953349632);
   expect(torrent.totalUploaded).toBe(0);

--- a/test/normalizeTorrentData.spec.ts
+++ b/test/normalizeTorrentData.spec.ts
@@ -1,0 +1,57 @@
+import { TorrentState } from '@ctrl/shared-torrent';
+import { expect, it } from 'vitest';
+
+import { normalizeTorrentData } from '../src/normalizeTorrentData.js';
+import type { TorrentData } from '../src/types.js';
+
+const baseTorrent: TorrentData = [
+  'ABCDEF0123456789ABCDEF0123456789ABCDEF01',
+  1,
+  'test.torrent',
+  1000,
+  500,
+  500,
+  0,
+  0,
+  0,
+  0,
+  0,
+  '',
+  0,
+  0,
+  0,
+  0,
+  0,
+  1,
+  500,
+  '',
+  '',
+  '',
+  '',
+  1_700_000_000,
+  0,
+  '',
+  '/downloads',
+  0,
+  '',
+  false,
+];
+
+it('normalizes uTorrent progress from tenths of a percent', () => {
+  const torrent = normalizeTorrentData(baseTorrent);
+
+  expect(torrent.progress).toBe(50);
+  expect(torrent.isCompleted).toBe(false);
+  expect(torrent.state).toBe(TorrentState.downloading);
+});
+
+it('classifies a completed started torrent as seeding', () => {
+  const torrentData: TorrentData = [...baseTorrent];
+  torrentData[4] = 1000;
+
+  const torrent = normalizeTorrentData(torrentData);
+
+  expect(torrent.progress).toBe(100);
+  expect(torrent.isCompleted).toBe(true);
+  expect(torrent.state).toBe(TorrentState.seeding);
+});

--- a/test/normalizeTorrentData.spec.ts
+++ b/test/normalizeTorrentData.spec.ts
@@ -43,15 +43,21 @@ it('normalizes uTorrent progress from tenths of a percent', () => {
   expect(torrent.progress).toBe(50);
   expect(torrent.isCompleted).toBe(false);
   expect(torrent.state).toBe(TorrentState.downloading);
+  expect(torrent.totalSize).toBe(1000);
+  expect(torrent.totalSelected).toBe(1000);
+  expect(torrent.dateCompleted).toBeUndefined();
 });
 
 it('classifies a completed started torrent as seeding', () => {
   const torrentData: TorrentData = [...baseTorrent];
   torrentData[4] = 1000;
+  torrentData[18] = 0;
+  torrentData[24] = 1_700_000_100;
 
   const torrent = normalizeTorrentData(torrentData);
 
   expect(torrent.progress).toBe(100);
   expect(torrent.isCompleted).toBe(true);
   expect(torrent.state).toBe(TorrentState.seeding);
+  expect(torrent.dateCompleted).toBe('2023-11-14T22:15:00.000Z');
 });


### PR DESCRIPTION
uTorrent reports progress in tenths of a percent, so `1000` means complete. The normalizer was dividing by 100, which made complete torrents look like 10% and kept them out of the seeding state.

Radarr’s uTorrent client also confirmed a couple of tuple details: index 18 is remaining bytes, not selected size, and incomplete torrents report completed date as `0`. This maps selected size from the torrent size and leaves `dateCompleted` unset until uTorrent has a real completed timestamp.

Adds pure tuple tests for the raw mapping plus a real-uTorrent integration assertion for incomplete `dateCompleted`, since that does not depend on download progress.